### PR TITLE
Introduce virtual shell, tighten web/FS handling, structured logging, config validation, update safety, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ NMAP's operating system fingerprints database can be found at: https://svn.nmap.
 
 Several services may be emulated, and some offer real interaction like FTP, Telnet, SSH, and HTTP(S). These services allow you to customize the port they run on, usernames:passwords that grant access to those services, and more. Many of these services provide file system access that you may customize to your liking. This may be a custom web page or pages in `./emulators/web_root`, or files in `./emulators/ftp_root` or `./emulators/telnet_root`. You may adjust the fingerprints to reflect the system type you are trying to emulate. I have provided some examples in `./samples/<service>.txt`. Please see [./samples/README.md](https://github.com/MakoWish/Faitour/tree/main/samples/README.md) for more details. 
 
+SSH and Telnet expose a deliberately limited virtual command interpreter. Commands operate only on their emulator root and are never passed to the host shell. Extend `utils/virtual_shell.py` when adding decoy commands; do not invoke host commands from an attacker-facing service.
+
+Submitted honeypot credentials, including plain-text passwords, are intentionally recorded in local events so the owner can analyze credential attacks. The supplied Elastic ingest pipeline redacts passwords before broader exposure. Protect local files and the systemd journal accordingly.
+
 Service Fingerprints can be found at: https://svn.nmap.org/nmap/nmap-service-probes
 
 Note that the majority of these fingerprints contain regex patterns. You should replace those regex patterns with data that would not only be matched by those patterns, but also matches the service you are attempting to spoof.
@@ -158,6 +162,13 @@ sudo ./faitour.py
 Once Faitour has been started, be sure to run an NMAP scan from another machine to ensure that everything is working as expected. 
 
 `nmap -sS -sV -O <ip address>`
+
+Contributors can run the non-privileged automated checks before deployment:
+
+```bash
+python3 -m unittest discover -s tests -v
+ruff check .
+```
 
 If using the default configuration, your results should look something like this:
 

--- a/emulators/http.py
+++ b/emulators/http.py
@@ -1,11 +1,11 @@
 import os
 import ssl
 import json
-import socket
 import threading
 import http.server
 import utils.config as config
-from socketserver import TCPServer
+from pathlib import Path
+from socketserver import ThreadingTCPServer
 from urllib.parse import parse_qs, urlunparse, urlparse
 from utils.logger import appLogger
 from utils.logger import honeyLogger
@@ -22,6 +22,17 @@ from cryptography.hazmat.primitives import serialization
 class LoginPageHandler(http.server.BaseHTTPRequestHandler):
 	http_root = "./emulators/http_root"
 	default_doc = config.get_service_by_name("http")["default_doc"]
+	max_request_body = 1024 * 1024
+
+	def resolve_request_path(self, path=None):
+		request_path = urlparse(path if path is not None else self.path).path
+		root = Path(self.http_root).resolve()
+		candidate = (root / request_path.lstrip("/")).resolve()
+		try:
+			candidate.relative_to(root)
+		except ValueError as exc:
+			raise PermissionError("Requested path is outside the HTTP root") from exc
+		return candidate
 
 	def log_message(self, format, *args):
 		# This method is overridden to do nothing, effectively disabling the log output
@@ -74,8 +85,6 @@ class LoginPageHandler(http.server.BaseHTTPRequestHandler):
 		honeyLogger.info(f'"type":["connection","denied"],"kind":"alert","category":["web","network","intrusion_detection"],"dataset":"faitour.honeypot","action":"http_get","reason":"HTTP GET Request","outcome":"failure"}},"source":{{"ip":"{self.client_address[0]}","port":{self.client_address[1]}}},"destination":{{"ip":"{self.server.server_address[0]}","port":{self.server.server_address[1]}}},"http":{{"request":{{"method":"GET"}},"response":{{"status_code":{response_code}}}}},"url":{{"full":{self.get_full_url()},"path":{json.dumps(self.path)}')
 		self.send_response(response_code)
 		self.send_header("Content-type", "text/html")
-		#self.set_common_headers()
-		self.send_header("Server", config.get_service_by_name("http")["server_header"])
 		self.end_headers()
 		error_page_path = f"{self.http_root}/error_pages/{response_code}.html"
 
@@ -85,12 +94,8 @@ class LoginPageHandler(http.server.BaseHTTPRequestHandler):
 				self.wfile.write(content.encode("utf-8"))
 		except FileNotFoundError:
 			# Fallback if custom error page is missing
-			if response_code == 401:
-				self.wfile.write(b"401 Unauthorized")
-			if response_code == 404:
-				self.wfile.write(b"403 Forbidden")
-			if response_code == 404:
-				self.wfile.write(b"404 Not Found")
+			fallbacks = {401: b"401 Unauthorized", 404: b"404 Not Found", 413: b"413 Payload Too Large"}
+			self.wfile.write(fallbacks.get(response_code, f"{response_code} Error".encode()))
 
 	def serve_page(self, method, status_code, path):
 		honeyLogger.info(f'"type":["connection","allowed","info"],"kind":"alert","category":["web","network","intrusion_detection"],"dataset":"faitour.honeypot","action":"http_get","reason":"HTTP {method} Request","outcome":"success"}},"source":{{"ip":"{self.client_address[0]}","port":{self.client_address[1]}}},"destination":{{"ip":"{self.server.server_address[0]}","port":{self.server.server_address[1]}}},"http":{{"request":{{"method":"{method}"}},"response":{{"status_code":{status_code}}}}},"url":{{"full":{self.get_full_url()},"path":{json.dumps(path)}')
@@ -98,65 +103,44 @@ class LoginPageHandler(http.server.BaseHTTPRequestHandler):
 		self.send_header("Content-type", "text/html")
 		if path == "/logout.html":
 			self.send_header("Set-Cookie", "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly")
-		self.send_header("Server", config.get_service_by_name("http")["server_header"])
 		self.end_headers()
-		with open(f"{self.http_root}{path}", "r") as file:
+		with self.resolve_request_path(path).open("r") as file:
 			self.wfile.write(file.read().encode("utf-8"))
 
 	def do_GET(self):
-		if self.path.endswith("README.md"):
-			# Explicitly return 404 for any README.md files
+		request_path = urlparse(self.path).path
+		if request_path.endswith("README.md"):
 			self.send_error_page(404)
-		elif os.path.exists(f"{self.http_root}/{self.path}"):
-			if os.path.isfile(f"{self.http_root}/{self.path}"):
-				# Check to see if this is a protected document
-				with open(f"{self.http_root}/{self.path}", "r") as file:
-					if "PROTECTED" in file.readline().strip():
-						protected = True
-					else:
-						protected = False
-
-				if protected:
-					if self.is_authenticated():
-						# Protected but authenticated. Serve the page.
-						self.serve_page("GET", 200, self.path)
-					else:
-						# Protected but not authenticated.
-						self.send_error_page(401)
-				else:
-					# Not protected. Serve the page.
-					self.serve_page("GET", 200, self.path)
-			else:
-				# Requested path was a directory. See if there is a default document
-				if os.path.exists(f"{self.http_root}/{self.path}/{self.default_doc}"):
-					# Check to see if this should be a protected document
-					with open(f"{self.http_root}/{self.path}/{self.default_doc}", "r") as file:
-						if "PROTECTED" in file.readline().strip():
-							protected = True
-						else:
-							protected = False
-
-					if protected:
-						if self.is_authenticated():
-							# Protected but authenticated. Serve the page.
-							self.serve_page("GET", 200, f"{self.path}/{self.default_doc}")
-						else:
-							# Protected but not authenticated.
-							self.send_error_page(401)
-					else:
-						# Not protected. Serve the page.
-						self.serve_page("GET", 200, f"{self.path}/{self.default_doc}")
-				else:
-					# Page does not exist.
-					self.send_error_page(404)
-		else:
-			# If it's any other path, return 404
+			return
+		try:
+			resolved_path = self.resolve_request_path(request_path)
+		except PermissionError:
 			self.send_error_page(404)
+			return
+		if resolved_path.is_dir():
+			request_path = f"{request_path.rstrip('/')}/{self.default_doc}"
+			resolved_path = self.resolve_request_path(request_path)
+		if not resolved_path.is_file():
+			self.send_error_page(404)
+			return
+		with resolved_path.open("r") as file:
+			protected = "PROTECTED" in file.readline().strip()
+		if protected and not self.is_authenticated():
+			self.send_error_page(401)
+			return
+		self.serve_page("GET", 200, request_path)
 
 	def do_POST(self):
 		# Parse the content type and content length
 		content_type = self.headers.get("Content-Type")
-		content_length = int(self.headers.get("Content-Length", 0))
+		try:
+			content_length = int(self.headers.get("Content-Length", 0))
+		except ValueError:
+			self.send_error_page(400)
+			return
+		if content_length < 0 or content_length > self.max_request_body:
+			self.send_error_page(413)
+			return
 
 		# Read the form data
 		try:
@@ -183,7 +167,6 @@ class LoginPageHandler(http.server.BaseHTTPRequestHandler):
 			cookie["session"]["httponly"] = True
 			cookie["session"]["max-age"] = 3600  # 1 hour
 			self.send_response(200)
-			self.send_header("Server", config.get_service_by_name("http")["server_header"])
 			self.send_header("Content-type", "text/html")
 			for morsel in cookie.values():
 				self.send_header("Set-Cookie", morsel.OutputString())
@@ -209,9 +192,9 @@ class WebServer:
 		if self.http_enabled:
 			self.running = True
 			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start_http","reason":"HTTP server emulator is starting on http://{self.host_ip}:{self.host_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
-			TCPServer.allow_reuse_address = True
-			httpd_http = TCPServer((self.host_ip, self.host_port), LoginPageHandler)
-			httpd_http.serve_forever()
+			ThreadingTCPServer.allow_reuse_address = True
+			self.httpd_http = ThreadingTCPServer((self.host_ip, self.host_port), LoginPageHandler)
+			self.httpd_http.serve_forever()
 			appLogger.info(f'"type":["start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start_http","reason":"HTTP server emulator has started on http://{self.host_ip}:{self.host_port}","outcome":"success"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
 
 	def start_https(self):
@@ -222,17 +205,17 @@ class WebServer:
 			self.generate_self_signed_cert()
 
 			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start_http","reason":"HTTPS server emulator is starting on https://{self.host_ip}:{self.https_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
-			TCPServer.allow_reuse_address = True
-			httpd_https = TCPServer((self.host_ip, self.https_port), LoginPageHandler)
+			ThreadingTCPServer.allow_reuse_address = True
+			self.httpd_https = ThreadingTCPServer((self.host_ip, self.https_port), LoginPageHandler)
 
 			# Create an SSL context
 			context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
 			context.load_cert_chain(certfile='./emulators/http_cert.pem', keyfile='./emulators/http_key.pem')
 
 			# Wrap the server socket with the SSL context
-			httpd_https.socket = context.wrap_socket(httpd_https.socket, server_side=True)
+			self.httpd_https.socket = context.wrap_socket(self.httpd_https.socket, server_side=True)
 
-			httpd_https.serve_forever()
+			self.httpd_https.serve_forever()
 			appLogger.info(f'"type":["start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start_http","reason":"HTTPS server emulator has started on https://{self.host_ip}:{self.https_port}","outcome":"success"}},"server":{{"ip":"{self.host_ip}","port":{self.https_port}')
 
 	def start_servers(self):
@@ -249,19 +232,19 @@ class WebServer:
 	def stop_servers(self):
 		# Stop the HTTP server if it's running
 		if self.httpd_http:
-			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTP server emulator is stopping","outcome":"unknown"')
+			appLogger.info('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTP server emulator is stopping","outcome":"unknown"')
 			self.httpd_http.shutdown()
 			self.httpd_http.server_close()
 			self.httpd_http = None
-			appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTP server emulator has stopped","outcome":"success"')
+			appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTP server emulator has stopped","outcome":"success"')
 
 		# Stop the HTTPS server if it's running
 		if self.httpd_https:
-			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTPS server emulator is stopping","outcome":"unknown"')
+			appLogger.info('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTPS server emulator is stopping","outcome":"unknown"')
 			self.httpd_https.shutdown()
 			self.httpd_https.server_close()
 			self.httpd_https = None
-			appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTPS server emulator has stopped","outcome":"success"')
+			appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop_servers","reason":"HTTPS server emulator has stopped","outcome":"success"')
 
 	def generate_self_signed_cert(self):
 		# Set cert and key paths
@@ -270,7 +253,7 @@ class WebServer:
 
 		# Check if the certificate and key files already exist
 		if os.path.exists(cert_path) and os.path.exists(key_path):
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"generate_self_signed_cert","reason":"HTTP certificate and key already exist","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"generate_self_signed_cert","reason":"HTTP certificate and key already exist","outcome":"success"')
 			return
 
 		# Generate a private key
@@ -326,4 +309,4 @@ class WebServer:
 				certificate.public_bytes(encoding=serialization.Encoding.PEM)
 			)
 
-		appLogger.debug(f'"type":["creation"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"generate_self_signed_cert","reason":"HTTPS Self-signed certificate and key generated","outcome":"success"')
+		appLogger.debug('"type":["creation"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"generate_self_signed_cert","reason":"HTTPS Self-signed certificate and key generated","outcome":"success"')

--- a/emulators/mssql.py
+++ b/emulators/mssql.py
@@ -15,7 +15,7 @@ class MSSQLEmulator:
 	# Start the MSSQL emulator server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MSSQL server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MSSQL server emulator is already running","outcome":"success"')
 			return
 
 		appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MSSQL server emulator is starting on {self.host_ip}:{self.host_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
@@ -58,7 +58,7 @@ class MSSQLEmulator:
 	# Stop the server.
 	def stop(self):
 		if not self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MSSQL server emulator is not running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MSSQL server emulator is not running","outcome":"success"')
 			return
 
 		if self.server_socket:

--- a/emulators/mysql.py
+++ b/emulators/mysql.py
@@ -15,7 +15,7 @@ class MySQLEmulator:
 	# Start the MySQL emulator server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MySQL server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MySQL server emulator is already running","outcome":"success"')
 			return
 
 		appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MySQL server emulator is starting on {self.host_ip}:{self.host_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
@@ -59,7 +59,7 @@ class MySQLEmulator:
 	# Stop the server.
 	def stop(self):
 		if not self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MySQL server emulator is not running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"MySQL server emulator is not running","outcome":"success"')
 			return
 
 		if self.server_socket:

--- a/emulators/netbios.py
+++ b/emulators/netbios.py
@@ -15,7 +15,7 @@ class NetBIOSEmulator:
 	# Start the NetBIOS emulator server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NetBIOS server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NetBIOS server emulator is already running","outcome":"success"')
 			return
 
 		appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NetBIOS server emulator is starting on {self.host_ip}:{self.host_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
@@ -59,7 +59,7 @@ class NetBIOSEmulator:
 	# Stop the server.
 	def stop(self):
 		if not self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NetBIOS server emulator is not running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NetBIOS server emulator is not running","outcome":"success"')
 			return
 
 		if self.server_socket:

--- a/emulators/postgresql.py
+++ b/emulators/postgresql.py
@@ -15,7 +15,7 @@ class PostgreSQLServer:
 	# Starts the emulated PostgreSQL server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"PostgreSQL server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"PostgreSQL server emulator is already running","outcome":"success"')
 			return
 
 		try:
@@ -73,7 +73,7 @@ class PostgreSQLServer:
 	# Stops the emulated PostgreSQL server.
 	def stop(self):
 		if not self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"PostgreSQL server emulator is not running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"PostgreSQL server emulator is not running","outcome":"success"')
 			return
 
 		self.running = False

--- a/emulators/rdp.py
+++ b/emulators/rdp.py
@@ -1,4 +1,3 @@
-import codecs
 import socket
 import threading
 import utils.config as config
@@ -16,7 +15,7 @@ class RDServer:
 	# Start the mock RDP server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RDP server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RDP server emulator is already running","outcome":"success"')
 			return
 
 		try:
@@ -39,12 +38,12 @@ class RDServer:
 			return
 
 		try:
-			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"RDP server emulator is stopping","outcome":"unknown"')
+			appLogger.info('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"RDP server emulator is stopping","outcome":"unknown"')
 			if self.server_socket:
 				self.server_socket.close()
 				self.server_socket = None
 			self.running = False
-			appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"RDP server emulator has stopped","outcome":"success"')
+			appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"RDP server emulator has stopped","outcome":"success"')
 		except Exception as e:
 			appLogger.error(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"handle_packet","reason":"RDP failed to stop server","outcome":"failure"}},"error":{{"message":"{e}"')
 

--- a/emulators/rpc.py
+++ b/emulators/rpc.py
@@ -15,7 +15,7 @@ class RPCEmulator:
 	# Start the RPC emulator server.
 	def start(self):
 		if self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RPC server emulator is already running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RPC server emulator is already running","outcome":"success"')
 			return
 
 		appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RPC server emulator is starting on {self.host_ip}:{self.host_port}","outcome":"unknown"}},"server":{{"ip":"{self.host_ip}","port":{self.host_port}')
@@ -59,7 +59,7 @@ class RPCEmulator:
 	# Stop the server.
 	def stop(self):
 		if not self.running:
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RPC server emulator is not running","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"RPC server emulator is not running","outcome":"success"')
 			return
 
 		if self.server_socket:

--- a/emulators/smbv2.py
+++ b/emulators/smbv2.py
@@ -50,12 +50,12 @@ class SMBv2Server:
 			return
 
 		try:
-			appLogger.info(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SMBv2 server emulator is stopping","outcome":"unknown"')
+			appLogger.info('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SMBv2 server emulator is stopping","outcome":"unknown"')
 			if self.running:
 				self.server_socket.close()
 				self.server_socket = None
 			self.running = False
-			appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SMBv2 server emulator has stopped","outcome":"success"')
+			appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SMBv2 server emulator has stopped","outcome":"success"')
 		except Exception as e:
 			appLogger.error(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"handle_packet","reason":"SMBv2 failed to stop server","outcome":"failure"}},"error":{{"message":"{e}"')
 
@@ -92,7 +92,7 @@ class SMBv2Server:
 			client_socket.close()
 
 	def process_request(self, request):
-		honeyLogger.info(f'"type":["connection","allowed","start"],"kind":"alert","category":["network","intrusion_detection"],"dataset":"faitour.honeypot","action":"process_request","reason":"Received request","outcome":"success"')
+		honeyLogger.info('"type":["connection","allowed","start"],"kind":"alert","category":["network","intrusion_detection"],"dataset":"faitour.honeypot","action":"process_request","reason":"Received request","outcome":"success"')
 		parts = request.split()
 
 		if len(parts) == 0:

--- a/emulators/snmp.py
+++ b/emulators/snmp.py
@@ -1,7 +1,6 @@
 import asyncio
 import utils.config
 from utils.logger import appLogger
-from utils.logger import honeyLogger
 from pysnmp.entity import engine, config
 from pysnmp.carrier.asyncio.dgram import udp
 from pysnmp.entity.rfc3413 import cmdrsp
@@ -62,7 +61,7 @@ class SNMPServer:
 			dispatcher = self.snmp_engine.transportDispatcher
 
 			if dispatcher is None:
-				appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"configure","reason":"Transport dispatcher not initialized","outcome":"failure"}},"error":{{"message":"Transport dispatcher not initialized"')
+				appLogger.error('"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"configure","reason":"Transport dispatcher not initialized","outcome":"failure"},"error":{"message":"Transport dispatcher not initialized"')
 
 			# Job Started signals that dispatcher will process requests
 			dispatcher.jobStarted(1)
@@ -73,12 +72,12 @@ class SNMPServer:
 	# Stop the SNMP server gracefully.
 	def stop(self):
 		try:
-			appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SNMP server emulator is stopping","outcome":"success"')
+			appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SNMP server emulator is stopping","outcome":"success"')
 			self.running = False
 			dispatcher = self.snmp_engine.transportDispatcher
 
 			if dispatcher:
 				dispatcher.closeDispatcher()
-				appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SNMP server emulator has stopped","outcome":"success"')
+				appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SNMP server emulator has stopped","outcome":"success"')
 		except Exception as e:
 			appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SNMP server emulator failed to stop","outcome":"failure"}},"error":{{"message":"{e}"')

--- a/emulators/ssh.py
+++ b/emulators/ssh.py
@@ -4,20 +4,14 @@ import codecs
 import socket
 import select
 import threading
-import traceback
 import utils.config as config
+from utils.virtual_shell import VirtualShell
 from utils.logger import appLogger
 from utils.logger import honeyLogger
 from paramiko import ServerInterface, Transport, AUTH_SUCCESSFUL, OPEN_SUCCEEDED, SFTPServer
-from paramiko.sftp_server import SFTPServerInterface, SFTPAttributes
+from paramiko.sftp_server import SFTPAttributes
 from paramiko import RSAKey
 #from socket import socket, AF_INET, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR
-from datetime import datetime, timedelta
-from cryptography import x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
 
 class SimpleSSHServer(ServerInterface):
 	ROOT_DIR = os.path.abspath("./emulators/ssh_root")
@@ -71,9 +65,10 @@ class SimpleSFTPServer(SFTPServer):
 		super().__init__(channel)
 
 	def _realpath(self, path):
-		real_path = os.path.abspath(os.path.join(SimpleSSHServer.ROOT_DIR, path.lstrip("/")))
-		if not real_path.startswith(SimpleSSHServer.ROOT_DIR):
-			appLogger.warning(f'"type":["connection","denied"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"_realpath","reason":"Access denied to path: {path}","outcome":"success"')
+		root = os.path.realpath(SimpleSSHServer.ROOT_DIR)
+		real_path = os.path.realpath(os.path.join(root, path.lstrip("/")))
+		if os.path.commonpath((root, real_path)) != root:
+			raise PermissionError(f"Access denied to path: {path}")
 		return real_path
 
 	def list_folder(self, path):
@@ -201,7 +196,7 @@ class SSHServer:
 
 			server.event.wait(10)
 			if not server.event.is_set():
-				appLogger.warning(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"run_server","reason":"SSH no shell request received, closing channel","outcome":"failure"')
+				appLogger.warning('"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"run_server","reason":"SSH no shell request received, closing channel","outcome":"failure"')
 				channel.close()
 				transport.close()
 				return
@@ -219,8 +214,7 @@ class SSHServer:
 			try:
 				client_socket.close()
 			except Exception:
-				logger.exception(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"run_server","reason":"Error closing client socket","outcome":"failure"')
-				appLogger.exception('Error closing client socket')
+				appLogger.exception('"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"run_server","reason":"Error closing client socket","outcome":"failure"')
 
 	def handle_shell(self, channel):
 		try:
@@ -232,6 +226,7 @@ class SSHServer:
 			channel.send(ssh_banner)
 
 			buffer = ""
+			shell = VirtualShell(SimpleSSHServer.ROOT_DIR)
 			channel.send(f"{self.bash_username}@{self.bash_hostname}:$ ")  # Send initial prompt
 			while True:
 				data = channel.recv(1024).decode("utf-8")
@@ -248,34 +243,9 @@ class SSHServer:
 							channel.send("\r\nGoodbye!\r\n")
 							return
 						elif command:
-							try:
-								# Change directory to ROOT_DIR to ensure isolation
-								os.chdir(f"{SimpleSSHServer.ROOT_DIR}/home/admin")
-
-								if command.startswith("cd "):
-									new_dir = command[3:]
-									new_path = os.path.abspath(os.path.join(SimpleSSHServer.ROOT_DIR, new_dir))
-									if new_path.startswith(SimpleSSHServer.ROOT_DIR):
-										os.chdir(new_path)
-										channel.send("\r\n")
-									else:
-										channel.send("\r\nAccess denied")
-								elif command == "pwd":
-									relative_path = os.path.relpath(os.getcwd(), SimpleSSHServer.ROOT_DIR)
-									channel.send(f"\r\n/{relative_path if relative_path != '.' else ''}")
-								else:
-									import subprocess
-
-									process = subprocess.Popen(
-										command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-									)
-									stdout, stderr = process.communicate()
-									if stdout:
-										channel.send(f"\r\n{stdout.strip()}")
-									if stderr:
-										channel.send(f"\r\n{stderr.strip()}")
-							except Exception as e:
-								channel.send(f"\r\nError executing command: {e}")
+							output = shell.run(command)
+							if output:
+								channel.send(f"\r\n{output}")
 						channel.send(f"\r\n{self.bash_username}@{self.bash_hostname}:$ ")  # Send prompt after processing command
 					else:
 						buffer += char
@@ -287,7 +257,7 @@ class SSHServer:
 
 	# Stops the SSH server.
 	def stop(self):
-		appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SSH server emulator is stopping","outcome":"success"')
+		appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SSH server emulator is stopping","outcome":"success"')
 		self.running = False
 		if self.server_socket:
 			self.server_socket.close()  # Interrupt the blocking accept() call
@@ -299,7 +269,7 @@ class SSHServer:
 			self.thread.join()  # Wait for the server thread to finish
 			self.thread = None
 
-		appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SSH server emulator has stopped","outcome":"success"')
+		appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"SSH server emulator has stopped","outcome":"success"')
 
 	# Generates a self-signed certificate and private key if they do not already exist.
 	def get_ssh_key(self):

--- a/emulators/telnet.py
+++ b/emulators/telnet.py
@@ -2,10 +2,10 @@ import os
 import codecs
 import socket
 import threading
-import subprocess
 import utils.config as config
 from utils.logger import appLogger
 from utils.logger import honeyLogger
+from utils.virtual_shell import VirtualShell
 
 class TelnetServer:
 	def __init__(self):
@@ -103,6 +103,7 @@ class TelnetServer:
 		# Handles interactions with the connected telnet client.
 		client_socket.send(config.get_service_by_name("telnet")["login_banner"].encode("utf-8"))
 		current_dir = self.root_dir
+		shell = VirtualShell(self.root_dir, start_dir=".")
 
 		try:
 			while True:
@@ -124,46 +125,9 @@ class TelnetServer:
 					client_socket.send(b"Goodbye!\n")
 					break
 
-				# Handle shell-like commands
-				if data.startswith("cd "):
-					path = data[3:].strip()
-					new_dir = os.path.abspath(os.path.join(current_dir, path))
-					# Ensure the directory is within the root_dir
-					if os.path.commonpath([self.root_dir, new_dir]) == self.root_dir and os.path.exists(new_dir) and os.path.isdir(new_dir):
-						current_dir = new_dir
-						honeyLogger.info(f'"type":["access","allowed"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User access to {new_dir} granted","outcome":"success"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"file":{{"directory":"{new_dir}"')
-					else:
-						client_socket.send(b"Directory not found or access denied.\n")
-						honeyLogger.error(f'"type":["access","denied"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User access to {new_dir} denied","outcome":"failure"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"file":{{"directory":"{new_dir}"')
-				elif data == "ls":
-					try:
-						files = os.listdir(current_dir)
-						response = "\n".join(files) + "\n"
-						client_socket.send(response.encode())
-						honeyLogger.info(f'"type":["access","allowed"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User listed directory {current_dir}","outcome":"success"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"file":{{"directory":"{current_dir}"')
-					except Exception as e:
-						client_socket.send(f"Error listing directory: {e}\n".encode())
-						honeyLogger.error(f'"type":["access","denied"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User attempt to list directory {current_dir} failed","outcome":"failure"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"error":{{"message":"{e}"}},"file":{{"directory":"{current_dir}"')
-				elif data.startswith("cat "):
-					filename = data[4:].strip()
-					filepath = os.path.abspath(os.path.join(current_dir, filename))
-					# Ensure the file is within the root_dir
-					if os.path.commonpath([self.root_dir, filepath]) == self.root_dir and os.path.exists(filepath) and os.path.isfile(filepath):
-						with open(filepath, 'r') as f:
-							client_socket.send(f.read().encode())
-							client_socket.send(b'\r\n')
-							honeyLogger.info(f'"type":["access","allowed"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User cat\'ed contents of file {filepath}","outcome":"success"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"file":{{"name":"{filename}","directory":"{filepath}"')
-					else:
-						client_socket.send(b"File not found or access denied.\n")
-						honeyLogger.error(f'"type":["access","denied"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User attempt to cat file {filepath} failed","outcome":"failure"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"error":{{"message":"File not found or access denied"')
-				else:
-					try:
-						result = subprocess.check_output(data, shell=True, cwd=current_dir, stderr=subprocess.STDOUT)
-						client_socket.send(result)
-						honeyLogger.info(f'"type":["access","allowed"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User ran unhandled command {data}","outcome":"success"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"')
-					except subprocess.CalledProcessError as e:
-						client_socket.send(e.output or b"Command failed.\n")
-						honeyLogger.error(f'"type":["access","denied"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User command {data} failed","outcome":"failure"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"}},"error":{{"message":"{e}"')
+					result = shell.run(data)
+					client_socket.send((result + "\n").encode())
+					honeyLogger.info(f'"type":["access","allowed"],"kind":"alert","category":["file","intrusion_detection"],"dataset":"faitour.honeypot","action":"handle_client","reason":"User ran virtual command {data}","outcome":"success"}},"source":{{"ip":"{client_ip}","port":{client_port}}},"destination":{{"ip":"{self.host_ip}","port":{self.host_port}}},"user":{{"name":"{username}","password":"{password}"')
 		except Exception as e:
 			appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"handle_client","reason":"Client error","outcome":"failure"}},"error":{{"message":"{e}"')
 		finally:
@@ -171,7 +135,7 @@ class TelnetServer:
 
 	# Stops the telnet server.
 	def stop(self):
-		appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"Telnet server emulator is stopping","outcome":"success"')
+		appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"Telnet server emulator is stopping","outcome":"success"')
 		self.running = False
 		if self.server_socket:
 			self.server_socket.close()
@@ -182,4 +146,4 @@ class TelnetServer:
 
 		# Clear the list of clients
 		self.clients = []
-		appLogger.info(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"Telnet server emulator has stopped","outcome":"success"')
+		appLogger.info('"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"stop","reason":"Telnet server emulator has stopped","outcome":"success"')

--- a/faitour.py
+++ b/faitour.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import sys
 import time
 import utils.config as config
 import handlers.intercept as intercept
@@ -16,12 +17,12 @@ def main():
 	# Ensure we are running as root/sudo
 	if os.geteuid() != 0:
 		appLogger.critical('"type":["start","error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"Application must be run as root/sudo","outcome":"failure"')
-		os._exit(5)
+		return 5
 
 	# Ensure our configuration looks okay
 	if not config.is_valid():
 		appLogger.critical('"type":["error"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"check_config","reason":"Default configuration found","outcome":"failure"')
-		return False
+		return 2
 
 	# Check if there are any updates available
 	if update_available(silent=True):
@@ -38,18 +39,24 @@ def main():
 	max_queue_size = config.get_value("network.max_queue_size")
 
 	# Start intercepting packets
-	intercept.start(max_queue_size)
+	try:
+		return intercept.start(max_queue_size)
+	finally:
+		emulators.stop()
 
 
 #===============================================================================
 # Application entry point
 #===============================================================================
 if __name__ == "__main__":
+	exit_code = 0
 	try:
-		main()
+		exit_code = main()
 	except Exception as e:
 		appLogger.error(f'"type":["end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"{e}","outcome":"failure"')
+		exit_code = 1
 	finally:
 		time.sleep(2) # Pause just to give things time to fully shut down in case of a service restart
-		appLogger.info('"type":["end","info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Faitour has stopped","outcome":"success"')
-		os._exit(0)
+		outcome = "success" if exit_code == 0 else "failure"
+		appLogger.info(f'"type":["end","info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Faitour has stopped","outcome":"{outcome}"')
+	sys.exit(exit_code)

--- a/handlers/inspect.py
+++ b/handlers/inspect.py
@@ -1,6 +1,3 @@
-import utils.config as config
-from utils.logger import appLogger
-from utils.logger import honeyLogger
 from utils.fingerprint import fingerprint
 from handlers.ecn_check import ecn_detect
 from handlers.udp_check import udp_detect

--- a/handlers/intercept.py
+++ b/handlers/intercept.py
@@ -1,11 +1,12 @@
-import base64
 import socket
+import subprocess
 import threading
+import time
 import utils.config as config
 from handlers.inspect import inspector
 from netfilterqueue import NetfilterQueue
-from subprocess import DEVNULL, STDOUT, check_call, Popen
-from scapy.all import *
+from subprocess import DEVNULL, STDOUT
+from scapy.all import ICMP, IP, TCP, UDP
 from scapy.contrib.igmp import IGMP
 from utils.logger import appLogger
 from utils.logger import honeyLogger
@@ -68,7 +69,7 @@ def handle_packet(nfq_packet):
 				nfq_packet.accept()
 
 		else:
-			appLogger.debug(f'"type":["connection","protocol","info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"intercept_packet","reason":"Non-IP packet received","outcome":"success"')
+			appLogger.debug('"type":["connection","protocol","info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"intercept_packet","reason":"Non-IP packet received","outcome":"success"')
 			nfq_packet.accept()
 
 	except Exception as e:
@@ -82,24 +83,48 @@ def handle_packet(nfq_packet):
 #===============================================================================
 # Function to add rules to iptables
 #===============================================================================
+FAITOUR_CHAIN = "FAITOUR"
+SYSCTL_KEYS = (
+	"net.ipv4.conf.all.arp_ignore",
+	"net.ipv4.conf.all.arp_announce",
+	"net.ipv4.conf.all.rp_filter",
+	"net.ipv4.ip_forward",
+)
+original_sysctls = {}
+
+
+def _run(command, check=True):
+	return subprocess.run(command, stdout=DEVNULL, stderr=STDOUT, check=check)
+
+
 def set_rules():
-	Popen(["sysctl", "net.ipv4.conf.all.arp_ignore=1"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["sysctl", "net.ipv4.conf.all.arp_announce=2"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["sysctl", "net.ipv4.conf.all.rp_filter=2"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["echo 1 | tee /proc/sys/net/ipv4/ip_forward"], stdout=DEVNULL, stderr=STDOUT, shell=True).wait()
-	Popen(["iptables", "-I", "INPUT", "-p", "tcp", "!", "-d", "127.0.0.1", "-j", "NFQUEUE", "--queue-num", "2"], stdout=DEVNULL, stderr=STDOUT).wait()
+	for key in SYSCTL_KEYS:
+		original_sysctls[key] = subprocess.check_output(["sysctl", "-n", key], text=True).strip()
+	for key, value in {
+		"net.ipv4.conf.all.arp_ignore": "1",
+		"net.ipv4.conf.all.arp_announce": "2",
+		"net.ipv4.conf.all.rp_filter": "2",
+		"net.ipv4.ip_forward": "1",
+	}.items():
+		_run(["sysctl", "-w", f"{key}={value}"])
+	_run(["iptables", "-N", FAITOUR_CHAIN], check=False)
+	_run(["iptables", "-F", FAITOUR_CHAIN])
+	if _run(["iptables", "-C", "INPUT", "-j", FAITOUR_CHAIN], check=False).returncode != 0:
+		_run(["iptables", "-I", "INPUT", "-j", FAITOUR_CHAIN])
+	for protocol in ("tcp", "udp", "icmp"):
+		_run(["iptables", "-A", FAITOUR_CHAIN, "-p", protocol, "!", "-d", "127.0.0.1", "-j", "NFQUEUE", "--queue-num", "2", "--queue-bypass"])
 
 
 #===============================================================================
 # Function to flush iptables and rules when shutting down
 #===============================================================================
 def flush_rules():
-	Popen(["sysctl", "net.ipv4.conf.all.arp_ignore=0"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["sysctl", "net.ipv4.conf.all.arp_announce=0"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["sysctl", "net.ipv4.conf.all.rp_filter=0"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["echo 0 | tee /proc/sys/net/ipv4/ip_forward"], stdout=DEVNULL, stderr=STDOUT, shell=True).wait()
-	Popen(["iptables", "-D", "INPUT", "-p", "tcp", "!", "-d", "127.0.0.1", "-j", "NFQUEUE", "--queue-num", "2"], stdout=DEVNULL, stderr=STDOUT).wait()
-	Popen(["iptables", "-F"], stdout=DEVNULL, stderr=STDOUT).wait()
+	while _run(["iptables", "-D", "INPUT", "-j", FAITOUR_CHAIN], check=False).returncode == 0:
+		pass
+	_run(["iptables", "-F", FAITOUR_CHAIN], check=False)
+	_run(["iptables", "-X", FAITOUR_CHAIN], check=False)
+	for key, value in original_sysctls.items():
+		_run(["sysctl", "-w", f"{key}={value}"], check=False)
 
 
 #===============================================================================
@@ -121,25 +146,25 @@ def monitor_nfqueue_queue_size(nfqueue, max_queue_size, stop_event, interval=1):
 
 							# I am keeping this service restart as a fail-safe to ensure no conflicts with Elastic Agent, but
 							# I believe the recent change to the IP Tables rule renders this entire queue monitoring method obsolete.
-							appLogger.warn(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
+							appLogger.warn('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
 							subprocess.run(["systemctl", "restart", "faitour.service"], check=False)
-							appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
+							appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
 					else:
-						appLogger.warn(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"Unexpected format in /proc/net/netfilter/nfnetlink_queue","outcome":"unknown"')
+						appLogger.warn('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"Unexpected format in /proc/net/netfilter/nfnetlink_queue","outcome":"unknown"')
 				else:
-					appLogger.warn(f'"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"/proc/net/netfilter/nfnetlink_queue is empty or unreadable","outcome":"unknown"')
+					appLogger.warn('"type":["info"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"/proc/net/netfilter/nfnetlink_queue is empty or unreadable","outcome":"unknown"')
 
 					# Issue with queue. Restart the service
-					appLogger.error(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
+					appLogger.error('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
 					subprocess.run(["systemctl", "restart", "faitour.service"], check=False)
-					appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
+					appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
 		except FileNotFoundError as e:
 			appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"/proc/net/netfilter/nfnetlink_queue not found","outcome":"failure"}},"error":{{"message":"{e}"}}')
 
 			# Restart the service since it appears NFQUEUE may not be running
-			appLogger.warn(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
+			appLogger.warn('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restart Faitour service...","outcome":"unknown"')
 			subprocess.run(["systemctl", "restart", "faitour.service"], check=False)
-			appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
+			appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"bind_nfqueue","reason":"Restarted Faitour service","outcome":"success"')
 		except Exception as e:
 			appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"monitor_nfqueue_queue_size","reason":"Error monitoring NFQUEUE queue size","outcome":"failure"}},"error":{{"message":"{e}"}}')
 
@@ -159,14 +184,22 @@ def start(max_queue_size):
 	whitelist_networks = load_whitelist(invalid_entry_callback=warn_invalid_whitelist_entry)
 
 	# Set our iptables and network rules
-	appLogger.info(f'"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"start","reason":"Network and iptables rules are being set","outcome":"unknown"')
-	set_rules()
-	appLogger.info(f'"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"end","reason":"Network and iptables rules have been set","outcome":"success"')
+	appLogger.info('"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"start","reason":"Network and iptables rules are being set","outcome":"unknown"')
+	try:
+		set_rules()
+	except Exception:
+		flush_rules()
+		raise
+	appLogger.info('"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"end","reason":"Network and iptables rules have been set","outcome":"success"')
 
 	# Create a NetfilterQueue object and bind it to queue number 2
 	nfqueue = NetfilterQueue()
-	nfqueue.bind(2, handle_packet, max_len=max_queue_size)
-	s = socket.fromfd(nfqueue.get_fd(), socket.AF_INET, socket.SOCK_STREAM)
+	try:
+		nfqueue.bind(2, handle_packet, max_len=max_queue_size)
+		s = socket.fromfd(nfqueue.get_fd(), socket.AF_INET, socket.SOCK_STREAM)
+	except Exception:
+		flush_rules()
+		raise
 
 	# Create a stop event for the monitor thread
 	stop_event = threading.Event()
@@ -176,30 +209,32 @@ def start(max_queue_size):
 	monitor_thread.daemon = True  # Ensure it terminates when the main program ends
 	monitor_thread.start()
 
+	exit_code = 0
 	try:
 		# Run the main nfqueue socket in the main thread
-		appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NFQUEUE socket is now intercepting packets","outcome":"success"')
+		appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"NFQUEUE socket is now intercepting packets","outcome":"success"')
 		nfqueue.run_socket(s)
 
 	except KeyboardInterrupt:
-		appLogger.info(f'"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Shutting down Faitour due to keyboard interrupt","outcome":"success"')
+		appLogger.info('"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Shutting down Faitour due to keyboard interrupt","outcome":"success"')
 	except Exception as e:
 		appLogger.error(f'"type":["error"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Shutting down Faitour due to unknown exception","outcome":"failure"}},"error":{{"message":"{e}"}}')
+		exit_code = 1
 	finally:
 		# Clean up resources
-		appLogger.info(f'"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"start","reason":"Network and iptables rules are being reset","outcome":"unknown"')
+		appLogger.info('"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"start","reason":"Network and iptables rules are being reset","outcome":"unknown"')
 		flush_rules()
-		appLogger.info(f'"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"end","reason":"Network and iptables rules have been reset","outcome":"success"')
+		appLogger.info('"type":["info","change"],"kind":"event","category":["configuration"],"dataset":"faitour.application","action":"end","reason":"Network and iptables rules have been reset","outcome":"success"')
 
-		appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"Unbinding NFQUEUE","outcome":"unknown"')
+		appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"Unbinding NFQUEUE","outcome":"unknown"')
 		nfqueue.unbind()
-		appLogger.info(f'"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"NFQUEUE has been unbound","outcome":"success"')
+		appLogger.info('"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"NFQUEUE has been unbound","outcome":"success"')
 
 		# Signal the monitor thread to stop and wait for it to finish
 		if monitor_thread.is_alive():
-			appLogger.info(f'"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"Terminating NFQUEUE monitor","outcome":"unknown"')
+			appLogger.info('"type":["info","start"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"start","reason":"Terminating NFQUEUE monitor","outcome":"unknown"')
 			stop_event.set()
 			monitor_thread.join()
-			appLogger.info(f'"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Terminated NFQUEUE monitor","outcome":"success"')
+			appLogger.info('"type":["info","end"],"kind":"event","category":["process"],"dataset":"faitour.application","action":"end","reason":"Terminated NFQUEUE monitor","outcome":"success"')
 
-	return 0
+	return exit_code

--- a/handlers/seqgen_check.py
+++ b/handlers/seqgen_check.py
@@ -1,9 +1,14 @@
 # All credit to eightus/Cyder for this one
 
+from binascii import crc32
+from struct import pack
 from scapy.all import IP, TCP, Ether
 from utils.config import if_sock
 from utils.logger import appLogger
-from utils.logger import honeyLogger
+
+CRCPOLY = 0xEDB88320
+CRCINV = 0x5B358FD3
+FINALXOR = 0xFFFFFFFF
 
 
 def seqgen_detect(nfq_packet, packet, fingerprint):
@@ -41,57 +46,57 @@ def seqgen_detect(nfq_packet, packet, fingerprint):
 	# ----------------------------------------------------------------------------
 
 	if nmap_seq1:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq1 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq1 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_1']:
 			spoofed_packet = craft(packet, fingerprint, '1')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	elif nmap_seq2:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq2 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq2 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_2']:
 			spoofed_packet = craft(packet, fingerprint, '2')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	elif nmap_seq3:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq3 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq3 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_3']:
 			spoofed_packet = craft(packet, fingerprint, '3')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	elif nmap_seq4:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq4 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq4 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_4']:
 			spoofed_packet = craft(packet, fingerprint, '4')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	elif nmap_seq5:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq5 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq5 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_5']:
 			spoofed_packet = craft(packet, fingerprint, '5')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	elif nmap_seq6:
-		appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq6 packet match","outcome":"success"')
+		appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Drop packet for match to nmap_seq6 packet match","outcome":"success"')
 		nfq_packet.drop()
 		if fingerprint.do_respond['PKT_6']:
 			spoofed_packet = craft(packet, fingerprint, '6')
 			if_sock.send(spoofed_packet)
-			appLogger.debug(f'"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
+			appLogger.debug('"type":["info"],"kind":"event","category":["network"],"dataset":"faitour.application","action":"seqgen_detect","reason":"Sending spoofed packet","outcome":"success"')
 		return True
 
 	else:

--- a/handlers/t2tot7_check.py
+++ b/handlers/t2tot7_check.py
@@ -1,8 +1,14 @@
 # All credit to eightus/Cyder for this one
 
 import random
+from binascii import crc32
+from struct import pack
 from scapy.all import IP, TCP, Ether
 from utils.config import if_sock
+
+CRCPOLY = 0xEDB88320
+CRCINV = 0x5B358FD3
+FINALXOR = 0xFFFFFFFF
 
 
 def t2tot7_detect(nfq_packet, packet, fingerprint):

--- a/handlers/udp_check.py
+++ b/handlers/udp_check.py
@@ -72,6 +72,8 @@ def craft(packet, fingerprint):
 		ipl = int(fingerprint.probe['U1']['IPL'], 16)
 	except KeyError:
 		ipl = None
+	if ipl is not None:
+		ip.len = ipl
 
 	data = packet[Raw].load
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "faitour"
+version = "2.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "cryptography>=41,<46",
+  "NetfilterQueue>=1.1,<2",
+  "paramiko>=3.4,<5",
+  "psutil>=5.9,<8",
+  "pyftpdlib>=1.5,<3",
+  "PyYAML>=6,<7",
+  "requests>=2.31,<3",
+  "scapy>=2.5,<3",
+  "smbprotocol>=1.12,<2",
+  "pysnmp>=6,<8",
+  "telnetlib3>=2,<3",
+]
+
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+try:
+	from utils import config
+except ModuleNotFoundError:
+	config = None
+
+
+@unittest.skipIf(config is None, "runtime configuration dependencies are not installed")
+class ConfigValidationTests(unittest.TestCase):
+	def test_repository_defaults_are_invalid(self):
+		errors = config.validation_errors(check_interface=False)
+		self.assertIn("network.adapter.name must be configured", errors)
+
+	def test_duplicate_enabled_ports_are_invalid(self):
+		custom = {
+			"network": {"adapter": {"name": "eth0", "ip": "192.0.2.1", "mac": "02:00:00:00:00:01"}},
+			"logging": {"level": "INFO"},
+			"services": [
+				{"name": "one", "enabled": True, "port": 80},
+				{"name": "two", "enabled": True, "port": 80},
+			],
+		}
+		with patch.object(config, "config", custom):
+			self.assertIn("enabled services must use unique ports", config.validation_errors(check_interface=False))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,24 @@
+import json
+import logging
+import unittest
+
+from utils.ecs_formatter import ECSFormatter
+
+
+class ECSFormatterTests(unittest.TestCase):
+	def test_valid_event_fragment_is_structured_json(self):
+		record = logging.LogRecord("test", logging.INFO, __file__, 10,
+			'"kind":"alert","reason":"captured"},"user":{"password":"plain-text"', (), None)
+		payload = json.loads(ECSFormatter().format(record))
+		self.assertEqual(payload["event"]["kind"], "alert")
+		self.assertEqual(payload["user"]["password"], "plain-text")
+
+	def test_attacker_controlled_invalid_fragment_still_emits_json(self):
+		record = logging.LogRecord("test", logging.INFO, __file__, 10,
+			'"reason":"bad\n\"value"', (), None)
+		payload = json.loads(ECSFormatter().format(record))
+		self.assertIn("message", payload)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,28 @@
+import tempfile
+import unittest
+from pathlib import Path
+from zipfile import ZipFile
+
+try:
+	from update import validate_archive_members, version_key
+except ModuleNotFoundError:
+	validate_archive_members = version_key = None
+
+
+@unittest.skipIf(version_key is None, "runtime updater dependencies are not installed")
+class UpdateTests(unittest.TestCase):
+	def test_versions_are_compared_numerically(self):
+		self.assertGreater(version_key("2.10.0"), version_key("2.9.0"))
+
+	def test_archive_traversal_is_rejected(self):
+		with tempfile.TemporaryDirectory() as directory:
+			archive = Path(directory) / "bad.zip"
+			with ZipFile(archive, "w") as output:
+				output.writestr("../escaped", "bad")
+			with ZipFile(archive) as source:
+				with self.assertRaises(ValueError):
+					validate_archive_members(source, Path(directory) / "destination")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_virtual_shell.py
+++ b/tests/test_virtual_shell.py
@@ -1,0 +1,34 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from utils.virtual_shell import VirtualShell
+
+
+class VirtualShellTests(unittest.TestCase):
+	def setUp(self):
+		self.temp_dir = tempfile.TemporaryDirectory()
+		root = Path(self.temp_dir.name)
+		(root / "home/admin").mkdir(parents=True)
+		(root / "home/admin/note.txt").write_text("decoy data")
+		self.shell = VirtualShell(root)
+
+	def tearDown(self):
+		self.temp_dir.cleanup()
+
+	def test_supported_commands_use_virtual_filesystem(self):
+		self.assertEqual(self.shell.run("pwd"), "/home/admin")
+		self.assertEqual(self.shell.run("cat note.txt"), "decoy data")
+		self.assertEqual(self.shell.run("echo hello world"), "hello world")
+
+	def test_commands_are_not_executed_by_host_shell(self):
+		self.assertEqual(self.shell.run("id"), "id: command not found")
+		self.assertEqual(self.shell.run("echo safe; touch escaped"), "safe; touch escaped")
+		self.assertFalse((Path(self.temp_dir.name) / "home/admin/escaped").exists())
+
+	def test_path_traversal_is_rejected(self):
+		self.assertIn("Access denied", self.shell.run("cat ../../../../etc/passwd"))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/update.py
+++ b/update.py
@@ -3,7 +3,6 @@
 import os
 import stat
 import shutil
-import requests
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -27,11 +26,13 @@ def get_local_version():
 
 # Check the version on GitHub
 def get_remote_version():
+	import requests
+
 	try:
 		response = requests.get(REPO_VERSION_URL, timeout=5)
 		response.raise_for_status()
 		return response.text.strip()
-	except requests.RequestException as e:
+	except requests.RequestException:
 		return None
 
 
@@ -59,8 +60,28 @@ def copy_with_permissions(src, dest):
     os.chmod(dest, st.st_mode)
 
 
+def version_key(version):
+	"""Compare dotted numeric versions without lexicographic ordering bugs."""
+	try:
+		return tuple(int(part) for part in version.split("."))
+	except (AttributeError, ValueError):
+		return ()
+
+
+def validate_archive_members(zip_ref, destination):
+	root = destination.resolve()
+	for member in zip_ref.infolist():
+		candidate = (root / member.filename).resolve()
+		try:
+			candidate.relative_to(root)
+		except ValueError as exc:
+			raise ValueError(f"Unsafe path in update archive: {member.filename}") from exc
+
+
 # Download and extract from GitHub
 def download_and_extract():
+	import requests
+
 	zip_path = Path("update.zip")
 	extracted_folder = None
 	try:
@@ -73,6 +94,7 @@ def download_and_extract():
 		exec_files = get_executable_files()
 
 		with ZipFile(zip_path, "r") as zip_ref:
+			validate_archive_members(zip_ref, Path.cwd())
 			archive_roots = {Path(name).parts[0] for name in zip_ref.namelist() if Path(name).parts}
 			if len(archive_roots) != 1:
 				raise ValueError("Update archive has an unexpected directory structure")
@@ -119,7 +141,7 @@ def check(silent=False):
 	if not local_version or not remote_version:
 		return False
 
-	if local_version < remote_version:
+	if version_key(local_version) < version_key(remote_version):
 		if silent:
 			return True
 		else:

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,4 +1,7 @@
 import yaml
+import ipaddress
+import logging
+import socket
 from scapy.all import conf
 
 
@@ -48,13 +51,41 @@ def get_service_by_name(name):
 # Verify network details have been configured (not default from Git)
 #===============================================================================
 def is_valid():
-	if get_value("network.adapter.name") == "change_me":
-		return False
-	if get_value("network.adapter.ip") == "10.0.0.0":
-		return False
-	if get_value("network.adapter.mac") == "00:11:22:33:44:55":
-		return False
-	return True
+	return not validation_errors()
+
+
+def validation_errors(check_interface=True):
+	errors = []
+	adapter = config.get("network", {}).get("adapter", {})
+	if adapter.get("name") in (None, "change_me"):
+		errors.append("network.adapter.name must be configured")
+	elif check_interface and adapter["name"] not in {name for _, name in socket.if_nameindex()}:
+		errors.append(f"network.adapter.name '{adapter['name']}' does not exist")
+	try:
+		address = ipaddress.ip_address(adapter.get("ip"))
+		if address.is_unspecified:
+			errors.append("network.adapter.ip cannot be an unspecified address")
+	except (TypeError, ValueError):
+		errors.append("network.adapter.ip must be a valid IP address")
+	mac = adapter.get("mac", "")
+	if mac == "00:11:22:33:44:55" or len(mac.split(":")) != 6:
+		errors.append("network.adapter.mac must be configured as six colon-separated octets")
+	if config.get("logging", {}).get("level") not in logging.getLevelNamesMapping():
+		errors.append("logging.level is invalid")
+	services = get_services()
+	names = [service.get("name") for service in services]
+	if len(names) != len(set(names)):
+		errors.append("service names must be unique")
+	ports = []
+	for service in services:
+		port = service.get("port")
+		if not isinstance(port, int) or not 1 <= port <= 65535:
+			errors.append(f"service '{service.get('name')}' has an invalid port")
+		if service.get("enabled"):
+			ports.append(port)
+	if len(ports) != len(set(ports)):
+		errors.append("enabled services must use unique ports")
+	return errors
 
 
 # Get the entire configuration to variable

--- a/utils/ecs_formatter.py
+++ b/utils/ecs_formatter.py
@@ -1,0 +1,24 @@
+import json
+import logging
+
+
+class ECSFormatter(logging.Formatter):
+	def format(self, record):
+		timestamp = self.formatTime(record, "%Y-%m-%dT%H:%M:%S") + f".{int(record.msecs):03d}"
+		base = {
+			"timestamp": timestamp,
+			"log": {"level": record.levelname, "logger": record.name,
+				"origin": {"file": {"line": record.lineno, "name": record.pathname}}},
+			"event": {"provider": record.module},
+		}
+		message = record.getMessage()
+		try:
+			fields = json.loads('{"event":{' + message + '}}')
+			base["event"].update(fields.pop("event", {}))
+			base.update(fields)
+		except (json.JSONDecodeError, TypeError, ValueError):
+			base["event"].update({"kind": "event", "category": ["process"], "outcome": "unknown"})
+			base["message"] = message
+		if record.exc_info:
+			base.setdefault("error", {})["stack_trace"] = self.formatException(record.exc_info)
+		return json.dumps(base, ensure_ascii=False, separators=(",", ":"))

--- a/utils/fingerprint.py
+++ b/utils/fingerprint.py
@@ -496,8 +496,6 @@ class Fingerprint:
 				df_flag = 2
 			else:
 				df_flag = 0
-		else:
-			new_probe = 0
 		self.probe['U1']['DF'] = df_flag
 
 		# Update Returned IP Length Value RIPL (UDP)
@@ -609,21 +607,6 @@ class Fingerprint:
 				temp_o_value.append(('SAckOK', b''))
 
 		return temp_o_value
-
-	def strhex2int(self, string):
-		try:
-			return int(string, 16)
-		except ValueError:
-			return int('0x' + string, 16)
-
-	def swapcheck(self, min_val, max_val):
-		small = self.strhex2int(min_val)
-		big = self.strhex2int(max_val)
-
-		if small > big:
-			small, big = big, small
-
-		return small, big
 
 	def fwd_look(self, string, start):
 		output = []

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -3,6 +3,7 @@ import time
 import logging
 import utils.config as config
 from logging.handlers import RotatingFileHandler
+from utils.ecs_formatter import ECSFormatter
 
 
 #===============================================================================
@@ -23,7 +24,7 @@ class Logger:
 		if stdout_logging:
 			# Add a stdout handler if enabled
 			stdoutLogger = logging.StreamHandler()
-			stdoutLogger.setFormatter(logging.Formatter('{"timestamp":"%(asctime)s.%(msecs)03d","log":{"level":"%(levelname)s","logger":"%(name)s","origin":{"file":{"line":%(lineno)s,"name":"%(pathname)s"}}},"event":{"provider":"%(module)s",%(message)s}}', datefmt='%Y-%m-%dT%H:%M:%S'))
+			stdoutLogger.setFormatter(ECSFormatter())
 			self.logger.addHandler(stdoutLogger)
 
 			# Confirm that our stdout logger has been configured
@@ -40,7 +41,7 @@ class Logger:
 
 			# Use a RotatingFileHandler for our file logger (log => log.1 => log.2 => ...)
 			fileLogger = RotatingFileHandler(log_dir + log_name, maxBytes=log_size, backupCount=log_count)
-			fileLogger.setFormatter(logging.Formatter('{"timestamp":"%(asctime)s.%(msecs)03d","log":{"level":"%(levelname)s","logger":"%(name)s","origin":{"file":{"line":%(lineno)s,"name":"%(pathname)s"}}},"event":{"provider":"%(module)s",%(message)s}}', datefmt='%Y-%m-%dT%H:%M:%S'))			
+			fileLogger.setFormatter(ECSFormatter())
 
 			# Add both file and stdout handlers to the logger
 			self.logger.addHandler(fileLogger)

--- a/utils/virtual_shell.py
+++ b/utils/virtual_shell.py
@@ -1,0 +1,64 @@
+import shlex
+from pathlib import Path
+
+
+class VirtualShell:
+	"""A small, non-executing shell backed by a confined directory tree."""
+
+	def __init__(self, root_dir, start_dir="home/admin"):
+		self.root = Path(root_dir).resolve()
+		self.root.mkdir(parents=True, exist_ok=True)
+		self.cwd = self._resolve(start_dir)
+		self.cwd.mkdir(parents=True, exist_ok=True)
+
+	def _resolve(self, path):
+		candidate = Path(path)
+		if candidate.is_absolute():
+			candidate = self.root / str(candidate).lstrip("/")
+		else:
+			candidate = self.cwd / candidate if hasattr(self, "cwd") else self.root / candidate
+		resolved = candidate.resolve()
+		try:
+			resolved.relative_to(self.root)
+		except ValueError as exc:
+			raise PermissionError("Access denied") from exc
+		return resolved
+
+	def run(self, command):
+		try:
+			args = shlex.split(command)
+		except ValueError as exc:
+			return f"shell: {exc}"
+		if not args:
+			return ""
+
+		name = args[0]
+		try:
+			if name == "pwd":
+				relative = self.cwd.relative_to(self.root)
+				return "/" + (str(relative) if str(relative) != "." else "")
+			if name == "cd":
+				target = self._resolve(args[1] if len(args) > 1 else "/home/admin")
+				if not target.is_dir():
+					return f"cd: {args[-1]}: No such directory"
+				self.cwd = target
+				return ""
+			if name in {"ls", "dir"}:
+				target = self._resolve(args[1] if len(args) > 1 else ".")
+				return "\n".join(sorted(item.name for item in target.iterdir()))
+			if name in {"cat", "type"}:
+				if len(args) != 2:
+					return f"Usage: {name} FILE"
+				return self._resolve(args[1]).read_text(errors="replace")
+			if name == "whoami":
+				return "admin"
+			if name == "uname":
+				return "Linux localhost 5.15.0 x86_64 GNU/Linux"
+			if name == "echo":
+				return " ".join(args[1:])
+			if name == "help":
+				return "Available commands: cat, cd, dir, echo, help, ls, pwd, type, uname, whoami"
+		except (OSError, PermissionError) as exc:
+			return f"{name}: {exc}"
+
+		return f"{name}: command not found"


### PR DESCRIPTION
### Motivation

- Harden emulators and prevent host command execution by confining attacker-facing shells and fixing path traversal risks in HTTP/SFTP/Telnet/SSH.  
- Improve observability by switching to a structured ECS-style logger and reduce accidental f-string formatting in logged payloads.  
- Make configuration checks and update procedures safer by validating config values and update archives and by fixing version comparisons.  
- Add packaging metadata and automated tests to enable CI-style validation before deployment.

### Description

- HTTP: added request path resolution via `LoginPageHandler.resolve_request_path`, request body size limit (`max_request_body`), safer file serving using `pathlib.Path` and deny-on-outside-root behavior, return proper error fallbacks, and switched to `ThreadingTCPServer` for concurrency.  
- SSH & Telnet: introduced `utils.virtual_shell.VirtualShell` and wired it into `emulators/ssh.py` and `emulators/telnet.py` so commands run against a confined virtual filesystem instead of invoking host shell; tightened SFTP `_realpath` to prevent traversal and raise `PermissionError`.  
- Logging & formatting: added `utils/ecs_formatter.py` and switched `utils.logger.Logger` handlers to use `ECSFormatter` to emit structured JSON events; cleaned up logging string usage to avoid accidental f-string evaluation.  
- Config & update safety: added robust validation in `utils/config.py` (`validation_errors` and `is_valid`), improved update logic in `update.py` (`version_key`, `validate_archive_members`) to compare dotted versions numerically and reject archive traversal, and fixed remote fetching to import `requests` locally.  
- Network/packet handling: refactored `handlers/intercept.py` to create a dedicated `FAITOUR` iptables chain, save/restore original `sysctl` values, provide `_run` wrapper for subprocesses, handle NFQUEUE bind errors with cleanup, and improve monitoring/monitor thread lifecycle and restart behavior.  
- Other improvements: switched many servers to use `SO_REUSEADDR` or threaded servers, improved start/stop semantics in `faitour.py` to return exit codes and ensure emulators are stopped on shutdown, added `pyproject.toml` and multiple unit tests under `tests/` (`test_config.py`, `test_logger.py`, `test_update.py`, `test_virtual_shell.py`).

### Testing

- Ran the test suite with `python3 -m unittest discover -s tests -v`, which executed the new unit tests and they passed.  
- Ran lint checks with `ruff check .` as suggested in `README.md` and the code passes the configured checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9710a72f90832483509a334f16509d)